### PR TITLE
Updating upload artifact action to v4

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -41,7 +41,7 @@ jobs:
           PUBLIC_VERSION: ${{ github.sha }}
         run: npm run build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: needs-assessment-${{ github.sha }}


### PR DESCRIPTION
### Context
The Upload Artifact Github Action V3 was deprecated and is now erroring out the test-and-release workflow as can be seen in https://github.com/distributeaid/needs-assessment/actions/runs/21260487239
To fix this, I am upgrading it to V4, the immediate next version to avoid hitting any breaking changes.